### PR TITLE
:rocket: Added a Makefile + prettier for backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.swp
 migrations/
 package-lock.json
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# Docker compose file location
+COMPOSE		=	docker-compose.yml
+
+# Change this to suit your compose version
+
+COMPOSE_CMD	= 	docker compose -f ${COMPOSE}
+
+build:
+	${COMPOSE_CMD} up --build
+
+up:
+	${COMPOSE_CMD} up
+
+down:
+	${COMPOSE_CMD} down
+
+dbclean: down
+	rm -rf back/prisma/migrations && docker volume prune -f
+
+clean: dbclean volume-clean
+	rm -rf back/dist back/node_modules front/node_modules
+
+fclean: down clean
+	docker system prune -af
+
+.PHONY: all build up down clean fclean

--- a/back/.eslintrc.js
+++ b/back/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
   plugins: ['@typescript-eslint/eslint-plugin'],
   extends: [
     'plugin:@typescript-eslint/recommended',
-    //'plugin:prettier/recommended',
+    'plugin:prettier/recommended',
     'plugin:unicorn/recommended',
   ],
   root: true,

--- a/back/package.json
+++ b/back/package.json
@@ -7,6 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "prisma:dev:deploy": "prisma migrate deploy",
+    "prisma:studio": "npx prisma studio &",
     "db:dev:restart": "yarn db:dev:rm && yarn db:dev:up",
     "db:dev:rm": "docker compose rm postgres -s -f -v",
     "db:dev:up": "docker compose up postgres -d",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     image: node:lts-alpine
     container_name: backend
     working_dir: /app
-    command: sh -c "yarn install && yarn global add @nestjs/cli && npx prisma migrate dev && yarn run start:dev" 
+    command: sh -c "yarn install && yarn global add @nestjs/cli && npx prisma migrate dev && yarn prisma:studio && yarn run start:dev" 
 #    build: ./back
     volumes:
       - ./back:/app
@@ -72,18 +72,3 @@ services:
     - backend
     depends_on:
       - back
-# PGADMIN  - commented as prisma studio does the same thing as pgAdmin
-#  pgadmin:
-#    container_name: pgadmin4
-#    image: dpage/pgadmin4
-#    restart: always
-#    environment:
-#      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL}
-#      - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD}
-#      - PGADMIN_LISTEN_PORT=${PGADMIN_LISTEN_PORT}
-#    ports:
-#      - "5050:5050"
-#    networks:
-#      - backend
-#    depends_on:
-#      - postgres


### PR DESCRIPTION
*
- Added a makefile
- :wastebasket: cleaned up the docker compose
- :rocket: autostart prisma studio on build
- :rocket: linter for back to have unique style
- update gitignore to remove .vscode
- make dbclean - remove migrations and postgres volume
	- allows a quick clean build
- make build run docker compose up --build
- make up runs docker compose up
- make clean removes node modules from front and back
- make fclean prunes docker for fresh build

:memo: change COMPOSE_CMD to docker-compose for 42 computers
-