### PR TITLE
Mvaldes/fix/2 fa user signin

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,8 +1,9 @@
 import { Outlet } from "react-router-dom";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "./App.css";
-import { createContext } from "react";
+import { createContext, useState } from "react";
 import { AuthStatus } from "./routes/Auth/AuthStatus";
+import { TAlert } from "./toasts/TAlert";
 
 let LoginStatus = {
   islogged: false,

--- a/front/src/modals/MActivateTwoFA.tsx
+++ b/front/src/modals/MActivateTwoFA.tsx
@@ -3,6 +3,7 @@ import { Modal, Button, Form } from "react-bootstrap";
 import { twoFAGenerate, twoFAOn } from "../queries/twoFAQueries";
 
 export function Activate2FA(props: any) {
+  
   const [image, setImage] = useState<string>("");
   const [FACodeModal, setCodeModal] = useState("");
 
@@ -27,7 +28,9 @@ export function Activate2FA(props: any) {
     e.preventDefault();
     const twoFAActivate = async () => {
       const result = await twoFAOn(FACodeModal);
-      if (result.success === "2FA turned on") props.onHide();
+      if (result.statusCode !== 200)
+        console.log("error: cannot deactivate 2FA");
+      else props.onHide();
     };
     twoFAActivate();
   };
@@ -73,7 +76,7 @@ export function Activate2FA(props: any) {
           type="submit"
           className="submit-button"
           size="sm"
-          onClick={(e:any) => {
+          onClick={(e: any) => {
             handleSubmit(e);
             props.onSubmit();
           }}

--- a/front/src/modals/MActivateTwoFA.tsx
+++ b/front/src/modals/MActivateTwoFA.tsx
@@ -29,7 +29,7 @@ export function Activate2FA(props: any) {
     const twoFAActivate = async () => {
       const result = await twoFAOn(FACodeModal);
       console.log("result.statusCode: ", result.statusCode);
-      if (result.statusCode !== undefined)
+      if (result.statusCode !== undefined || result.statusCode === 401)
         console.log("error: cannot activate 2FA");
       else props.onHide();
     };

--- a/front/src/modals/MActivateTwoFA.tsx
+++ b/front/src/modals/MActivateTwoFA.tsx
@@ -31,6 +31,7 @@ export function Activate2FA(props: any) {
       else {
         props.onHide();
         props.onSubmit();
+        localStorage.setItem("userAuth", "true");
       }
     };
     twoFAActivate();

--- a/front/src/modals/MActivateTwoFA.tsx
+++ b/front/src/modals/MActivateTwoFA.tsx
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from "react";
 import { Modal, Button, Form } from "react-bootstrap";
 import { twoFAGenerate, twoFAOn } from "../queries/twoFAQueries";
 
-// Enable 2FA modal
-
 export function Activate2FA(props: any) {
   const [image, setImage] = useState<string>("");
   const [FACodeModal, setCodeModal] = useState("");
@@ -20,7 +18,7 @@ export function Activate2FA(props: any) {
       };
       QRCode()
         .then((data) => setImage(data))
-        .then(() => console.log("hellow"));
+        .then(() => console.log("QR code generated"));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.show]);
@@ -75,7 +73,10 @@ export function Activate2FA(props: any) {
           type="submit"
           className="submit-button"
           size="sm"
-          onClick={props.setAuthStatus}
+          onClick={(e:any) => {
+            handleSubmit(e);
+            props.onSubmit();
+          }}
         >
           Submit
         </Button>

--- a/front/src/modals/MActivateTwoFA.tsx
+++ b/front/src/modals/MActivateTwoFA.tsx
@@ -4,7 +4,7 @@ import { twoFAGenerate, twoFAOn } from "../queries/twoFAQueries";
 
 // Enable 2FA modal
 
-export function Activate2FA(props: { show: boolean, onHide: () => void }) {
+export function Activate2FA(props: { show: boolean; onHide: () => void }) {
   const [image, setImage] = useState<string>("");
   const [FACodeModal, setCodeModal] = useState("");
 
@@ -22,14 +22,15 @@ export function Activate2FA(props: { show: boolean, onHide: () => void }) {
         .then((data) => setImage(data))
         .then(() => console.log("hellow"));
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.show]);
 
   const handleSubmit = (e: any) => {
     e.preventDefault();
-    console.log("", FACodeModal);
     const twoFAActivate = async () => {
-      return await twoFAOn(FACodeModal);
+      const result = await twoFAOn(FACodeModal);
+      if (result.success === "2FA turned on")
+        props.onHide();
     };
     twoFAActivate();
   };

--- a/front/src/modals/MActivateTwoFA.tsx
+++ b/front/src/modals/MActivateTwoFA.tsx
@@ -28,8 +28,9 @@ export function Activate2FA(props: any) {
     e.preventDefault();
     const twoFAActivate = async () => {
       const result = await twoFAOn(FACodeModal);
-      if (result.statusCode !== 200)
-        console.log("error: cannot deactivate 2FA");
+      console.log("result.statusCode: ", result.statusCode);
+      if (result.statusCode !== undefined)
+        console.log("error: cannot activate 2FA");
       else props.onHide();
     };
     twoFAActivate();

--- a/front/src/modals/MActivateTwoFA.tsx
+++ b/front/src/modals/MActivateTwoFA.tsx
@@ -4,7 +4,7 @@ import { twoFAGenerate, twoFAOn } from "../queries/twoFAQueries";
 
 // Enable 2FA modal
 
-export function Activate2FA(props: { show: boolean; onHide: () => void }) {
+export function Activate2FA(props: any) {
   const [image, setImage] = useState<string>("");
   const [FACodeModal, setCodeModal] = useState("");
 
@@ -29,8 +29,7 @@ export function Activate2FA(props: { show: boolean; onHide: () => void }) {
     e.preventDefault();
     const twoFAActivate = async () => {
       const result = await twoFAOn(FACodeModal);
-      if (result.success === "2FA turned on")
-        props.onHide();
+      if (result.success === "2FA turned on") props.onHide();
     };
     twoFAActivate();
   };
@@ -76,9 +75,7 @@ export function Activate2FA(props: { show: boolean; onHide: () => void }) {
           type="submit"
           className="submit-button"
           size="sm"
-          onClick={(e: any) => {
-            handleSubmit(e);
-          }}
+          onClick={props.setAuthStatus}
         >
           Submit
         </Button>

--- a/front/src/modals/MActivateTwoFA.tsx
+++ b/front/src/modals/MActivateTwoFA.tsx
@@ -3,7 +3,6 @@ import { Modal, Button, Form } from "react-bootstrap";
 import { twoFAGenerate, twoFAOn } from "../queries/twoFAQueries";
 
 export function Activate2FA(props: any) {
-  
   const [image, setImage] = useState<string>("");
   const [FACodeModal, setCodeModal] = useState("");
 
@@ -28,10 +27,11 @@ export function Activate2FA(props: any) {
     e.preventDefault();
     const twoFAActivate = async () => {
       const result = await twoFAOn(FACodeModal);
-      console.log("result.statusCode: ", result.statusCode);
-      if (result.statusCode !== undefined || result.statusCode === 401)
-        console.log("error: cannot activate 2FA");
-      else props.onHide();
+      if (!result) console.log("error: cannot activate 2FA");
+      else {
+        props.onHide();
+        props.onSubmit();
+      }
     };
     twoFAActivate();
   };
@@ -79,7 +79,6 @@ export function Activate2FA(props: any) {
           size="sm"
           onClick={(e: any) => {
             handleSubmit(e);
-            props.onSubmit();
           }}
         >
           Submit

--- a/front/src/queries/authQueries.tsx
+++ b/front/src/queries/authQueries.tsx
@@ -18,24 +18,31 @@ const fetchPost = async (
 ) => {
   let fetchUrl = "http://localhost:4000/auth/" + url;
 
-  const rest = await fetch(fetchUrl, {
-    method: "POST",
-    headers: myHeaders,
-    body: raw,
-    redirect: "follow",
-  }).then((response) => response.json());
-  // check if user is 2FA
-  if (rest.twoFA) {
-    // redirect to 2FA page
-    const url = '/2FA?user=' + rest.username;
-    window.location.href = url;
-    // NavigateTwoFA(rest.username);
-  } else {
-    storeToken(userInfo, rest);
-    if (localStorage.getItem("userToken")) {
-      await getUserData();
-      if (localStorage.getItem("userName")) userSignIn();
+  try {
+    const response = await fetch(fetchUrl, {
+      method: "POST",
+      headers: myHeaders,
+      body: raw,
+      redirect: "follow",
+    });
+    const result_1 = await response.json();
+    if (!response.ok) return console.log("POST error on ", url);
+    // check if user is 2FA
+    if (result_1.twoFA) {
+      // redirect to 2FA page
+      const url = "/2FA?user=" + result_1.username;
+      window.location.href = url;
+      // NavigateTwoFA(rest.username);
+    } else {
+      userInfo.clear();
+      storeToken(result_1);
+      if (localStorage.getItem("userToken")) {
+        await getUserData();
+        if (localStorage.getItem("userName")) userSignIn();
+      }
     }
+  } catch (error) {
+    return console.log("error", error);
   }
 };
 
@@ -56,11 +63,9 @@ export const signUp = (userInfo: any, userSignIn: any) => {
   fetchPost(raw, userInfo, userSignIn, "signup");
 };
 
-const storeToken = (userInfo: any, token: any) => {
-  if (!(token.error === "Forbidden")) {
-    console.log("token= ", token.access_token);
-    localStorage.setItem("userToken", token.access_token);
-    localStorage.setItem("userRefreshToken", token.refresh_token);
-  }
-  userInfo.clear();
+export const storeToken = (token: any) => {
+  console.log("token= ", token.access_token);
+  console.log("refresh token = ", token.access_token);
+  localStorage.setItem("userToken", token.access_token);
+  localStorage.setItem("userRefreshToken", token.refresh_token);
 };

--- a/front/src/queries/authQueries.tsx
+++ b/front/src/queries/authQueries.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { TAlert } from "../toasts/TAlert";
 import { getUserData } from "./userQueries";
 
 let myHeaders = new Headers();
@@ -26,7 +27,10 @@ const fetchPost = async (
       redirect: "follow",
     });
     const result_1 = await response.json();
-    if (!response.ok) return console.log("POST error on ", url);
+    if (!response.ok) {
+      console.log("POST error on ", url);
+      return "error";
+    }
     // check if user is 2FA
     if (result_1.twoFA) {
       // redirect to 2FA page
@@ -51,7 +55,7 @@ export const signIn = (userInfo: any, userSignIn: any) => {
     username: userInfo.email,
     password: userInfo.password,
   });
-  fetchPost(raw, userInfo, userSignIn, "signin");
+  return fetchPost(raw, userInfo, userSignIn, "signin");
 };
 
 export const signUp = (userInfo: any, userSignIn: any) => {
@@ -60,7 +64,7 @@ export const signUp = (userInfo: any, userSignIn: any) => {
     password: userInfo.password,
     username: userInfo.username,
   });
-  fetchPost(raw, userInfo, userSignIn, "signup");
+  return fetchPost(raw, userInfo, userSignIn, "signup");
 };
 
 export const storeToken = (token: any) => {

--- a/front/src/queries/authQueries.tsx
+++ b/front/src/queries/authQueries.tsx
@@ -29,7 +29,7 @@ const fetchPost = async (
     const result_1 = await response.json();
     if (!response.ok) {
       console.log("POST error on ", url);
-      return "error";
+      return "error: signIn";
     }
     // check if user is 2FA
     if (result_1.twoFA) {
@@ -43,6 +43,7 @@ const fetchPost = async (
       if (localStorage.getItem("userToken")) {
         await getUserData();
         if (localStorage.getItem("userName")) userSignIn();
+        else return "error: getUserData";
       }
     }
   } catch (error) {

--- a/front/src/queries/authQueries.tsx
+++ b/front/src/queries/authQueries.tsx
@@ -1,7 +1,14 @@
+import { useNavigate } from "react-router-dom";
 import { getUserData } from "./userQueries";
 
 let myHeaders = new Headers();
 myHeaders.append("Content-Type", "application/json");
+
+// const NavigateTwoFA = (username: string) => {
+//   console.log("username navigate: ", username);
+//   let navigate = useNavigate();
+//   navigate("/2FA?user=" + username);
+// };
 
 const fetchPost = async (
   raw: string,
@@ -22,14 +29,14 @@ const fetchPost = async (
     // redirect to 2FA page
     const url = '/2FA?user=' + rest.username;
     window.location.href = url;
-    //console.log(rest.twoFA);
+    // NavigateTwoFA(rest.username);
   } else {
-  storeToken(userInfo, rest);
-  if (localStorage.getItem("userToken")) {
-    await getUserData();
-    if (localStorage.getItem("userName")) userSignIn();
+    storeToken(userInfo, rest);
+    if (localStorage.getItem("userToken")) {
+      await getUserData();
+      if (localStorage.getItem("userName")) userSignIn();
+    }
   }
-}
 };
 
 export const signIn = (userInfo: any, userSignIn: any) => {

--- a/front/src/queries/twoFAQueries.tsx
+++ b/front/src/queries/twoFAQueries.tsx
@@ -50,6 +50,7 @@ const fetchPost = async (body: any, url: string) => {
       redirect: "follow",
     });
     const result_1 = await response.json();
+    console.log("query result: ", result_1);
     return result_1;
   } catch (error) {
     return console.log("error", error);

--- a/front/src/queries/twoFAQueries.tsx
+++ b/front/src/queries/twoFAQueries.tsx
@@ -6,12 +6,11 @@ export const twoFAGenerate = () => {
 };
 
 /* Validate 2FA code when signin in  */
-export const twoFAAuth = (twoFAcode: string, email: string) => {
+export const twoFAAuth = (twoFAcode: string, email: string, userSignIn:any) => {
   let raw = JSON.stringify({
     username: email,
     twoFAcode: twoFAcode,
   });
-  console.log('raw', raw);
   return fetchValid(raw, "authenticate", userSignIn);
 };
 
@@ -53,12 +52,11 @@ const fetchPost = async (body: any, url: string) => {
 const fetchValid = async (body: any, url: string, userSignIn: any) => {
   let fetchUrl = "http://localhost:4000/auth/2fa/" + url;
   let myHeaders = new Headers();
+  console.log("fetchValid body: ", body);
   // need to send JSON header
   myHeaders.append("Content-Type", "application/json");
   try {
-    console.log('body is', body);
-    
-    const response = await fetch(fetchUrl, {
+     const response = await fetch(fetchUrl, {
       method: "POST",
       headers: myHeaders,
       body: body,
@@ -84,8 +82,3 @@ const storeToken = (token: any) => {
     localStorage.setItem("userRefreshToken", token.refresh_token);
   }
 };
-
-/* NOT IMPLEMENTED */
-function userSignIn() {
-  throw new Error("Function not implemented.");
-}

--- a/front/src/queries/twoFAQueries.tsx
+++ b/front/src/queries/twoFAQueries.tsx
@@ -6,7 +6,11 @@ export const twoFAGenerate = () => {
 };
 
 /* Validate 2FA code when signin in  */
-export const twoFAAuth = (twoFAcode: string, email: string, userSignIn:any) => {
+export const twoFAAuth = (
+  twoFAcode: string,
+  email: string,
+  userSignIn: any
+) => {
   let raw = JSON.stringify({
     username: email,
     twoFAcode: twoFAcode,
@@ -20,6 +24,10 @@ export const twoFAOn = (code: string) => {
     twoFAcode: code,
   });
   return fetchPost(raw, "turn-on");
+};
+
+export const twoFAOff = () => {
+  return fetchPost(null, "turn-off");
 };
 
 const authRawHeader = () => {
@@ -56,14 +64,13 @@ const fetchValid = async (body: any, url: string, userSignIn: any) => {
   // need to send JSON header
   myHeaders.append("Content-Type", "application/json");
   try {
-     const response = await fetch(fetchUrl, {
+    const response = await fetch(fetchUrl, {
       method: "POST",
       headers: myHeaders,
       body: body,
       redirect: "follow",
     }).then((response) => response.json());
     storeToken(response);
-    // Similar to authqueries logic
     if (localStorage.getItem("userToken")) {
       await getUserData();
       if (localStorage.getItem("userName")) userSignIn();

--- a/front/src/queries/twoFAQueries.tsx
+++ b/front/src/queries/twoFAQueries.tsx
@@ -51,8 +51,10 @@ const fetchPost = async (body: any, url: string, userSignIn: any) => {
       redirect: "follow",
     });
     const result_1 = await response.json();
-    if (!response.ok)
-      return console.log("POST error on ", url);
+    if (!response.ok) {
+      console.log("POST error on ", url);
+      return null;
+    }
     if (url !== "generate") {
       storeToken(result_1);
       if (url === "authenticate") {

--- a/front/src/queries/updateUserQueries.tsx
+++ b/front/src/queries/updateUserQueries.tsx
@@ -36,24 +36,31 @@ const authFileHeader = () => {
   return myHeaders;
 };
 
-const fetchPost = (
+const fetchPost = async (
   bodyContent: any,
   url: string,
   header: any,
   data: string
 ) => {
   let fetchUrl = "http://localhost:4000/users/" + url;
-  fetch(fetchUrl, {
-    method: "POST",
-    headers: header(),
-    body: bodyContent,
-    redirect: "follow",
-  })
-    .then((response) => response.text())
-    // .then((result) => console.log(result))
-    .then(() => storeUserModif(url, data))
-    .then(() => console.log("user update"))
-    .catch((error) => console.log("error", error));
+
+  try {
+    const response = await fetch(fetchUrl, {
+      method: "POST",
+      headers: header(),
+      body: bodyContent,
+      redirect: "follow",
+    });
+    await response.json();
+    if (!response.ok) {
+      console.log("POST error on ", url);
+      return "error";
+    }
+    storeUserModif(url, data);
+    return "success";
+  } catch (error) {
+    return console.log("error", error);
+  }
 };
 
 const storeUserModif = (url: string, data: string) => {

--- a/front/src/queries/updateUserQueries.tsx
+++ b/front/src/queries/updateUserQueries.tsx
@@ -1,5 +1,3 @@
-import { storeUserInfo } from "./userQueries";
-
 export const updateAvatarQuery = (file: any) => {
   var formdata = new FormData();
   formdata.append("avatar", file.files[0], "avatar.jpeg");

--- a/front/src/queries/userFriendsQueries.tsx
+++ b/front/src/queries/userFriendsQueries.tsx
@@ -57,8 +57,9 @@ const fetchGet = async (url: string, header: any, body: any) => {
       body: body,
       redirect: "follow",
     });
-    const result_1 = await response.json();
-    console.log("result: ", result_1);
+    await response.json();
+    if (!response.ok) return console.log("POST error on ", url);
+    return console.log("POST sucess on ", url);
   } catch (error) {
     return console.log("error", error);
   }

--- a/front/src/queries/userQueries.tsx
+++ b/front/src/queries/userQueries.tsx
@@ -31,6 +31,7 @@ const fetchGet = async (url: string, header: any, callback: any) => {
       redirect: "follow",
     });
     const result_1 = await response.json();
+    if (!response.ok) return console.log("POST error on ", url);
     return callback(result_1);
   } catch (error) {
     return console.log("error", error);
@@ -50,5 +51,4 @@ export const storeUserInfo = (result: any) => {
 
 export const storeFriendsInfo = (result: any) => {
   return result;
-  // add blocked users later
 };

--- a/front/src/queries/userQueries.tsx
+++ b/front/src/queries/userQueries.tsx
@@ -40,12 +40,12 @@ const fetchGet = async (url: string, header: any, callback: any) => {
 export const storeUserInfo = (result: any) => {
   localStorage.setItem("userID", result.id);
   localStorage.setItem("userName", result.username);
-  localStorage.setItem("userEmail", "back sends email");
-  localStorage.setItem("userPicture", result.picture);
+  localStorage.setItem("userEmail", result.email);
+  localStorage.setItem("userPicture", result.avatar);
   localStorage.setItem("userGamesWon", result.gamesWon);
   localStorage.setItem("userGamesLost", result.gamesLost);
   localStorage.setItem("userGamesPlayed", result.gamesPlayed);
-  // localStorage.setItem("userAuth", result.twoFA);SET 2FA STATUS IN BACK
+  localStorage.setItem("userAuth", result.twoFA);
 };
 
 export const storeFriendsInfo = (result: any) => {

--- a/front/src/queries/userQueries.tsx
+++ b/front/src/queries/userQueries.tsx
@@ -31,7 +31,10 @@ const fetchGet = async (url: string, header: any, callback: any) => {
       redirect: "follow",
     });
     const result_1 = await response.json();
-    if (!response.ok) return console.log("POST error on ", url);
+    if (!response.ok) {
+      console.log("POST error on ", url);
+      return "error";
+    }
     return callback(result_1);
   } catch (error) {
     return console.log("error", error);

--- a/front/src/routes/Auth/Auth.tsx
+++ b/front/src/routes/Auth/Auth.tsx
@@ -13,7 +13,7 @@ export default function Auth() {
   let navigate = useNavigate();
   let auth = useAuth();
   let location = useLocation();
-  
+
   // Use a callback to avoid re-rendering
   const userSignIn = useCallback(() => {
     let username = localStorage.getItem("userName");
@@ -22,11 +22,11 @@ export default function Auth() {
       auth.signin(username, () => {
         navigate("/app/private-profile", { replace: true });
       });
-      console.log("user is signed in");
+    console.log("user is signed in");
   }, [navigate, auth]);
 
   // useEffect to get access token from URL
-    useEffect(() => {
+  useEffect(() => {
     // get access token from URL Query
     const access_token = location.search.split("=")[1];
     if (access_token) {
@@ -36,14 +36,12 @@ export default function Auth() {
       // to operate after the function, it needs to use await, asyn and .then
       // keywords. Otherwise, things might happen in the wrong order.
       const fetchData = async () => {
-       const data = await getUserData(); 
-      }
+        const data = await getUserData();
+      };
       // sign in the user
-      fetchData()
-      .then (() => userSignIn())
-      }
-    } , [location.search, userSignIn]);
-
+      fetchData().then(() => userSignIn());
+    }
+  }, [location.search, userSignIn]);
 
   const handleSubmit = (event: any) => {
     let userInfo: IUserInfo = {
@@ -56,7 +54,7 @@ export default function Auth() {
         this.password = null;
       },
     };
- 
+
     event.preventDefault();
     if (GUserInputsRefs.username.current?.value)
       userInfo.username = GUserInputsRefs.username.current.value;
@@ -98,7 +96,12 @@ export default function Auth() {
             </Form.Text>
           </Form.Group>
           {/* USE LINK TO GET USER FROM 42 API */}
-          <Button variant="secondary" className="submit-button" size="sm" href="http://localhost:4000/auth/42">
+          <Button
+            variant="secondary"
+            className="submit-button"
+            size="sm"
+            href="http://localhost:4000/auth/42"
+          >
             Sign in with 42
           </Button>
           <Button

--- a/front/src/routes/Auth/Auth.tsx
+++ b/front/src/routes/Auth/Auth.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
@@ -8,11 +8,14 @@ import { signUp, signIn } from "../../queries/authQueries";
 import { GUserInputsRefs } from "../../globals/variables";
 import { useAuth } from "../../globals/contexts";
 import { getUserData } from "../../queries/userQueries";
+import { TAlert } from "../../toasts/TAlert";
 
 export default function Auth() {
   let navigate = useNavigate();
   let auth = useAuth();
   let location = useLocation();
+  const [showNotif, setShowNotif] = useState(false);
+  const [notifText, setNotifText] = useState("Error");
 
   // Use a callback to avoid re-rendering
   const userSignIn = useCallback(() => {
@@ -63,11 +66,23 @@ export default function Auth() {
     userInfo.password = GUserInputsRefs!.password!.current!.value;
     if (userInfo.username && userInfo.email && userInfo.password)
       signUp(userInfo, userSignIn);
-    else signIn(userInfo, userSignIn);
+    else {
+      const signInUser = async () => {
+        const result = await signIn(userInfo, userSignIn);
+        if (result && result.includes("error")) {
+          result.includes("signIn")
+            ? setNotifText("User does not exists. Please enter a valid email and/or username.")
+            : setNotifText("Could not retreive user. Please try again.");
+          setShowNotif(true);
+        }
+      };
+      signInUser();
+    }
   };
 
   return (
     <div className="Auth-form-container">
+      <TAlert show={showNotif} setShow={setShowNotif} text={notifText} />
       <form className="Auth-form" onSubmit={handleSubmit}>
         <div className="Auth-form-content">
           <Outlet />

--- a/front/src/routes/Auth/Auth.tsx
+++ b/front/src/routes/Auth/Auth.tsx
@@ -30,10 +30,7 @@ export default function Auth() {
     // get access token from URL Query
     const access_token = location.search.split("=")[1];
     if (access_token) {
-      // LOG
       console.log(access_token);
-      //storeToken(access_token); --> Add function <--
-      // set the token into localstorage
       localStorage.setItem("userToken", access_token);
       // getUserData is a fetch that might take time. In order for sign in
       // to operate after the function, it needs to use await, asyn and .then

--- a/front/src/routes/Auth/Auth.tsx
+++ b/front/src/routes/Auth/Auth.tsx
@@ -37,6 +37,7 @@ export default function Auth() {
       // keywords. Otherwise, things might happen in the wrong order.
       const fetchData = async () => {
         const data = await getUserData();
+        console.log("data: ", data);
       };
       // sign in the user
       fetchData().then(() => userSignIn());

--- a/front/src/routes/TwoFAValidation.tsx
+++ b/front/src/routes/TwoFAValidation.tsx
@@ -8,52 +8,43 @@ export default function TwoFAValidation() {
   let location = useLocation();
   let navigate = useNavigate();
   let auth = useAuth();
+  let username = localStorage.getItem("userName");
 
   const [twoFACode, setCode] = useState("");
 
   const handleInputChange = (e: any) => {
-    const { name, value } = e.target;
+    const { value } = e.target;
     setCode(value);
   };
 
-  const userSignIn = useCallback(() => {
-    let tmpUsername = localStorage.getItem("tmpUsername");
-    console.log("userSignIn tmpUsername: ", tmpUsername);
-    if (tmpUsername !== "undefined")
-      auth.signin(tmpUsername, () => {
-        navigate("/app/private-profile", { replace: true });
-        console.log("user is signed in");
-      });
-    else {
-      console.log("user is not authorized");
-    }
-  }, [navigate, auth]);
-
   // get username from redirect URL
   useEffect(() => {
-    const username = location.search.split("=")[1];
-    if (username) {
-      console.log("URL username: ", username);
-      localStorage.setItem("tmpUsername", username);
+    const urlUsername = location.search.split("=")[1];
+    if (urlUsername) {
+      localStorage.setItem("userName", urlUsername);
       navigate("/2FA");
     }
   }, [location.search, navigate]);
 
-
-
   const handleSubmit = (e: any) => {
     e.preventDefault();
-    const tmpUsername = localStorage.getItem("tmpUsername");
-    if (tmpUsername !== "undefined" && tmpUsername) {
+
+    const userSignIn = () => {
+      let username = localStorage.getItem("userName");
+      console.log("username: ", username);
+      if (username)
+        auth.signin(username, () => {
+          navigate("/app/private-profile", { replace: true });
+        });
+      console.log("user is signed in");
+    };
+
+    if (username !== "undefined" && username) {
       const twoFAValid = async (username: string) => {
         return await twoFAAuth(twoFACode, username, userSignIn);
       };
-      twoFAValid(tmpUsername);
-      // remove temp email from local storage
-      //localStorage.removeItem("tmpUsername");
-    }
-    else
-      console.log("username is undefined");
+      twoFAValid(username);
+    } else console.log("username is undefined");
   };
 
   return (

--- a/front/src/routes/TwoFAValidation.tsx
+++ b/front/src/routes/TwoFAValidation.tsx
@@ -8,7 +8,13 @@ export default function TwoFAValidation() {
   let location = useLocation();
   let navigate = useNavigate();
   let auth = useAuth();
+
   const [twoFACode, setCode] = useState("");
+
+  const handleInputChange = (e: any) => {
+    const { name, value } = e.target;
+    setCode(value);
+  };
 
   const userSignIn = useCallback(() => {
     let tmpUsername = localStorage.getItem("tmpUsername");
@@ -33,10 +39,7 @@ export default function TwoFAValidation() {
     }
   }, [location.search, navigate]);
 
-  const handleInputChange = (e: any) => {
-    const { name, value } = e.target;
-    setCode(value);
-  };
+
 
   const handleSubmit = (e: any) => {
     e.preventDefault();
@@ -52,6 +55,7 @@ export default function TwoFAValidation() {
     else
       console.log("username is undefined");
   };
+
   return (
     <div>
       <Form.Group className="mb-3">

--- a/front/src/routes/profile_types/TwoFA.tsx
+++ b/front/src/routes/profile_types/TwoFA.tsx
@@ -8,8 +8,7 @@ export const TwoFA = (props: any) => {
     e.preventDefault();
     const twoFADeactivate = async () => {
       const result = await twoFAOff();
-      if (result.statusCode !== 200)
-        console.log("error: cannot deactivate 2FA");
+      if (!result) console.log("error: cannot deactivate 2FA");
       else
         props.onDeactivate();
     };

--- a/front/src/routes/profile_types/TwoFA.tsx
+++ b/front/src/routes/profile_types/TwoFA.tsx
@@ -10,7 +10,10 @@ export const TwoFA = (props: any) => {
       const result = await twoFAOff();
       if (!result) console.log("error: cannot deactivate 2FA");
       else
+      {
         props.onDeactivate();
+        localStorage.setItem("userAuth", "false");
+      }
     };
     twoFADeactivate();
   };

--- a/front/src/routes/profile_types/TwoFA.tsx
+++ b/front/src/routes/profile_types/TwoFA.tsx
@@ -8,6 +8,10 @@ export const TwoFA = (props: any) => {
     e.preventDefault();
     const twoFADeactivate = async () => {
       const result = await twoFAOff();
+      if (result.statusCode !== 200)
+        console.log("error: cannot deactivate 2FA");
+      else
+        props.onDeactivate();
     };
     twoFADeactivate();
   };

--- a/front/src/routes/profile_types/TwoFA.tsx
+++ b/front/src/routes/profile_types/TwoFA.tsx
@@ -6,7 +6,6 @@ export const TwoFA = (props: any) => {
       <Row className="wrapper p-3">
         <Col className="text-wrapper col-8">
           <div className="IBM-text" style={{ fontSize: "15px" }}>
-            {/* FETCH THE BACK TO SEE IF 2FA IS ENABLED */}
             <span>
               {props.auth === "true"
                 ? "Two Factor authentifcation enabled"
@@ -19,7 +18,6 @@ export const TwoFA = (props: any) => {
             type="button"
             className="btn btn-secondary btn-sm submit-button float-end"
             onClick={props.onClick}
-            // onClick={}
           >
             {props.auth === "true" ? "Remove 2FA" : "Activate 2FA"}
           </button>

--- a/front/src/routes/profile_types/TwoFA.tsx
+++ b/front/src/routes/profile_types/TwoFA.tsx
@@ -1,6 +1,7 @@
 import { Row, Col } from "react-bootstrap";
 
 export const TwoFA = (props: any) => {
+  console.log("2FA ? ", props.auth);
   return (
     <div>
       <Row className="wrapper p-3">

--- a/front/src/routes/profile_types/TwoFA.tsx
+++ b/front/src/routes/profile_types/TwoFA.tsx
@@ -1,7 +1,17 @@
 import { Row, Col } from "react-bootstrap";
+import { twoFAOff } from "../../queries/twoFAQueries";
 
 export const TwoFA = (props: any) => {
   console.log("2FA ? ", props.auth);
+
+  const handleTurnOff = (e: any) => {
+    e.preventDefault();
+    const twoFADeactivate = async () => {
+      const result = await twoFAOff();
+    };
+    twoFADeactivate();
+  };
+
   return (
     <div>
       <Row className="wrapper p-3">
@@ -18,7 +28,9 @@ export const TwoFA = (props: any) => {
           <button
             type="button"
             className="btn btn-secondary btn-sm submit-button float-end"
-            onClick={props.onClick}
+            onClick={
+              props.auth === "true" ? (e) => handleTurnOff(e) : props.onClick
+            }
           >
             {props.auth === "true" ? "Remove 2FA" : "Activate 2FA"}
           </button>

--- a/front/src/routes/profile_types/UserPrivateProfile.tsx
+++ b/front/src/routes/profile_types/UserPrivateProfile.tsx
@@ -35,12 +35,14 @@ export default function UserPrivateProfile() {
 
   const [modalShow, setModalShow] = useState(false);
   const [modalShowAuth, setModalShowAuth] = useState(false);
+  const [authStatus, setAuthStatus] = useState(false);
 
   return (
     <main>
       <MUploadAvatar show={modalShow} onHide={() => setModalShow(false)} />
       <Activate2FA
         show={modalShowAuth}
+        setAuthStatus={() => setAuthStatus(true)}
         onHide={() => setModalShowAuth(false)}
       />
 

--- a/front/src/routes/profile_types/UserPrivateProfile.tsx
+++ b/front/src/routes/profile_types/UserPrivateProfile.tsx
@@ -35,14 +35,14 @@ export default function UserPrivateProfile() {
 
   const [modalShow, setModalShow] = useState(false);
   const [modalShowAuth, setModalShowAuth] = useState(false);
-  const [authStatus, setAuthStatus] = useState(false);
+  const [authStatus, setAuthStatus] = useState(userInfo.auth);
 
   return (
     <main>
       <MUploadAvatar show={modalShow} onHide={() => setModalShow(false)} />
       <Activate2FA
         show={modalShowAuth}
-        setAuthStatus={() => setAuthStatus(true)}
+        onSubmit={() => setAuthStatus("true")}
         onHide={() => setModalShowAuth(false)}
       />
 
@@ -147,7 +147,7 @@ export default function UserPrivateProfile() {
                   </Row>
                 </div>
                 <TwoFA
-                  auth={userInfo.auth}
+                  auth={authStatus}
                   onClick={() => setModalShowAuth(true)}
                 />
               </Card.Body>

--- a/front/src/routes/profile_types/UserPrivateProfile.tsx
+++ b/front/src/routes/profile_types/UserPrivateProfile.tsx
@@ -149,6 +149,7 @@ export default function UserPrivateProfile() {
                 <TwoFA
                   auth={authStatus}
                   onClick={() => setModalShowAuth(true)}
+                  onDeactivate={() => setAuthStatus("false")}
                 />
               </Card.Body>
             </Card>

--- a/front/src/routes/profile_types/users_relations/BlockedList.tsx
+++ b/front/src/routes/profile_types/users_relations/BlockedList.tsx
@@ -28,7 +28,7 @@ export const BlockedList = () => {
         blocked.push(newRow);
       }
       setBlockedList(blocked);
-      console.log("blockedList: ", blockedList);
+      if (fetchedBlocked.length !== 0) console.log("blockedList", blockedList);
       setFetched(true);
       setUpdate(false);
     };

--- a/front/src/routes/profile_types/users_relations/FriendsList.tsx
+++ b/front/src/routes/profile_types/users_relations/FriendsList.tsx
@@ -16,42 +16,47 @@ export const FriendsList = () => {
   useEffect(() => {
     const fetchData = async () => {
       let fetchedFriends = await getUserFriends();
-
-      for (let i = 0; i < fetchedFriends.length; i++) {
-        let newRow: ItableRow = {
-          key: i,
-          userModel: { username: "", avatar: "", id: 0 },
-        };
-        newRow.userModel.id = fetchedFriends[i].id;
-        newRow.userModel.username = fetchedFriends[i].username;
-        newRow.userModel.avatar = fetchedFriends[i].avatar;
-        friends.push(newRow);
+      if (fetchedFriends.length !== 0) {
+        for (let i = 0; i < fetchedFriends.length; i++) {
+          let newRow: ItableRow = {
+            key: i,
+            userModel: { username: "", avatar: "", id: 0 },
+          };
+          newRow.userModel.id = fetchedFriends[i].id;
+          newRow.userModel.username = fetchedFriends[i].username;
+          newRow.userModel.avatar = fetchedFriends[i].avatar;
+          friends.push(newRow);
+        }
       }
       setFriendsList(friends);
-      console.log("friendsList", friendsList);
+      if (fetchedFriends.length !== 0) console.log("friendsList", friendsList);
       setFetched(true);
       setUpdate(false);
     };
 
     fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFetched, isUpdated]);
 
   return (
     <div style={{ overflowY: "auto", overflowX: "hidden" }}>
       {isFetched ? (
-        friendsList?.length !== 0 ? 
-        friendsList!.map((h, index) => {
-          return (
-            <DisplayRow
-              listType={"friends"}
-              hook={setUpdate}
-              key={index}
-              userModel={h.userModel}
-            />
-          );
-        }) : <span>No friends.</span>
+        friendsList?.length !== 0 ? (
+          friendsList!.map((h, index) => {
+            return (
+              <DisplayRow
+                listType={"friends"}
+                hook={setUpdate}
+                key={index}
+                userModel={h.userModel}
+              />
+            );
+          })
+        ) : (
+          <span>No friends.</span>
+        )
       ) : (
-        <div>No Data available, please reload.</div>
+        <div>No friends.</div>
       )}
     </div>
   );

--- a/front/src/routes/profile_types/users_relations/PendingList.tsx
+++ b/front/src/routes/profile_types/users_relations/PendingList.tsx
@@ -28,7 +28,7 @@ export const PendingList = () => {
         pending.push(newRow);
       }
       setPendingList(pending);
-      console.log("pendingList: ", pendingList);
+       if (fetchedPending.length !== 0) console.log("pendingList", pendingList);
       setFetched(true);
       setUpdate(false);
     };

--- a/front/src/toasts/TAlert.tsx
+++ b/front/src/toasts/TAlert.tsx
@@ -1,18 +1,33 @@
-import { useState } from "react";
 import { ToastContainer } from "react-bootstrap";
 import Toast from "react-bootstrap/Toast";
 
-export const TAlert = () => {
-  const [show, setShow] = useState(true);
+const getDate = () => {
+  let newDate = new Date();
+  let formattedDate = newDate.getMonth() + 1 + "/" + newDate.getDate();
+  return formattedDate;
+};
+
+const getTime = () => {
+  let newDate = new Date();
+  const time = newDate.getHours() + "h" + newDate.getMinutes();
+  return time;
+};
+
+export const TAlert = (props: any) => {
   return (
     <ToastContainer position="bottom-end" className="p-3">
-      <Toast onClose={() => setShow(false)} show={show} delay={3000} autohide>
+      <Toast
+        onClose={() => props.setShow(false)}
+        show={props.show}
+        delay={5000}
+        autohide
+      >
         <Toast.Header>
           <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
-          <strong className="me-auto">Bootstrap</strong>
-          <small>11 mins ago</small>
+          <strong className="me-auto">Notification Alert</strong>
+          <small>{getTime()}</small>
         </Toast.Header>
-        <Toast.Body>Woohoo, you're reading this text in a Toast!</Toast.Body>
+        <Toast.Body style={{ color: "black" }}>{props.text}</Toast.Body>
       </Toast>
     </ToastContainer>
   );

--- a/front/src/toasts/TAlert.tsx
+++ b/front/src/toasts/TAlert.tsx
@@ -1,0 +1,19 @@
+import { useState } from "react";
+import { ToastContainer } from "react-bootstrap";
+import Toast from "react-bootstrap/Toast";
+
+export const TAlert = () => {
+  const [show, setShow] = useState(true);
+  return (
+    <ToastContainer position="bottom-end" className="p-3">
+      <Toast onClose={() => setShow(false)} show={show} delay={3000} autohide>
+        <Toast.Header>
+          <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
+          <strong className="me-auto">Bootstrap</strong>
+          <small>11 mins ago</small>
+        </Toast.Header>
+        <Toast.Body>Woohoo, you're reading this text in a Toast!</Toast.Body>
+      </Toast>
+    </ToastContainer>
+  );
+};


### PR DESCRIPTION
- 2FA status updates in the front when turning it on or off
- 2FA turn on and off now receives tokens and stores it in localStorage
- the fetch queries are now protected and returns errors on cases, when the `!response.ok`
-  system of alerts on fetch error for signin, want to use it for the rest of the fetches but not on this pull request

Next is:

- implement alerts for all fetches errors
- logout implementation in the front